### PR TITLE
allow specify paths with more than 1 segments

### DIFF
--- a/behave_http/utils.py
+++ b/behave_http/utils.py
@@ -45,7 +45,10 @@ def dereference_step_parameters_and_data(f):
 
 def append_path(url, url_path):
     target = URL(url_path)
-    url = url.path(target.path())
+    if url_path.startswith('/'):
+        url = url.path(target.path())
+    else:
+        url = url.add_path_segment(target.path())
     if target.query():
         url = url.query(target.query())
     return url.as_string()

--- a/behave_http/utils.py
+++ b/behave_http/utils.py
@@ -43,9 +43,9 @@ def dereference_step_parameters_and_data(f):
     return wrapper
 
 
-def append_path(url, url_path_segment):
-    target = URL(url_path_segment)
-    url = url.add_path_segment(target.path())
+def append_path(url, url_path):
+    target = URL(url_path)
+    url = url.path(target.path())
     if target.query():
         url = url.query(target.query())
     return url.as_string()

--- a/features/http.feature
+++ b/features/http.feature
@@ -20,6 +20,10 @@ Feature: HTTP requests
     When I make a GET request to "get"
     Then the response status should be 200
 
+  Scenario: Test GET request with full path
+    When I make a GET request to "/test/get"
+    Then the response status should be 200
+
   Scenario: Test POST request
     When I make a POST request to "post"
     Then the response status should be 204


### PR DESCRIPTION
Example:

``` gherkin
Feature: allow specify full paths
  In order to specify full paths in my features to make requests
  behave-http will need to allow set full paths as well as relative ones

  Scenario Outline: response with appropriate status on incoming requests
    Given I am using server "$TEST_SERVER"
    When I make a GET request to "<path>"
    Then the response status should be <code>

    Examples: good services
    | path                     | code |
    | /good/service            |  200 |
    | /good/service?is_that=ok |  200 |

    Examples: bad services
    | path                     | code |
    | /bad/service             |  404 |
    | /good/service?is_that=no |  503 |
```
